### PR TITLE
Fixed schematics' blocks spawned twice and overriding the real schematic.

### DIFF
--- a/MapEditorReborn/API/Features/Objects/SchematicObject.cs
+++ b/MapEditorReborn/API/Features/Objects/SchematicObject.cs
@@ -208,10 +208,13 @@
 
         private void CreateRecursiveFromID(int id, List<SchematicBlockData> blocks, Transform parentGameObject)
         {
-            Transform childGameObjectTransform = CreateObject(SchematicData.Blocks.Find(c => c.ObjectId == id), parentGameObject) ?? transform; // Create the object first before creating children.
-
-            foreach (SchematicBlockData block in SchematicData.Blocks.FindAll(c => c.ParentId == id))
+            Transform childGameObjectTransform = CreateObject(blocks.Find(c => c.ObjectId == id), parentGameObject) ?? transform; // Create the object first before creating children.
+            int[] parentSchematics = blocks.Where(bl => bl.BlockType == BlockType.Schematic).Select(bl => bl.ObjectId).ToArray(); // Gets all the ObjectIds of all the schematic blocks inside "blocks" argument.
+            foreach (SchematicBlockData block in blocks.FindAll(c => c.ParentId == id))
             {
+                if (parentSchematics.Contains(block.ParentId)) // The block is a child of some schematic inside "parentSchematics" array, therefore it will be skipped to avoid spawning it and his childrens twice.
+                    continue;
+
                 CreateRecursiveFromID(block.ObjectId, blocks, childGameObjectTransform); // The child now becomes the parent
             }
         }

--- a/MapEditorReborn/API/Features/Objects/SchematicObject.cs
+++ b/MapEditorReborn/API/Features/Objects/SchematicObject.cs
@@ -212,7 +212,7 @@
             int[] parentSchematics = blocks.Where(bl => bl.BlockType == BlockType.Schematic).Select(bl => bl.ObjectId).ToArray(); // Gets all the ObjectIds of all the schematic blocks inside "blocks" argument.
             foreach (SchematicBlockData block in blocks.FindAll(c => c.ParentId == id))
             {
-                if (parentSchematics.Contains(block.ParentId)) // The block is a child of some schematic inside "parentSchematics" array, therefore it will be skipped to avoid spawning it and his childrens twice.
+                if (parentSchematics.Contains(block.ParentId)) // The block is a child of some schematic inside "parentSchematics" array, therefore it will be skipped to avoid spawning it and its children twice.
                     continue;
 
                 CreateRecursiveFromID(block.ObjectId, blocks, childGameObjectTransform); // The child now becomes the parent


### PR DESCRIPTION
SInce the method which handles the spawn of every block is recursive, it tooks a little bit long for me to figure out how to solve this issue.

What's the issue then?
Alright, we're spawning our schematic which contains more schematics, and they can also contain more schematics and so on.
What MER does is iterating over the `SchematicDataBlock`s contained in the schematic .json file, it computes the `BlockType` of the block, which can also be a `BlockType::Schematic`, and it spawns the block.
When a schematic block is spawned, the schematic itself is also spawned of course, but MER now doesn't check if the ObjectId of the current (and spawned) block, is parent of one or more blocks inside the blocks inside the .json file.
So the result will be a double schematic which overrides the real one, and you'll end up dealing with two schematics.
This is a big, huge issue, because since you're spawning two schematics, the server will have its primitives capacity halved, which means that if you want to make a big map that needs a lot of primitives, if you nest schematics into schematics (which is a smart move if you don't want to keep copy-paste every primitive) you'll have TWO instances of that schematic, and it's basically spawning 2x (x*2) primitives. This leads to a lot of issues about memory, the actual primitives loaded into the server (server-load), the schematics overridden and unable to play animations as they should do, and more things about the server load which I'm not gonna explain here because too technical and boring.

What's the solution?
It's simple, just check whether the next block in the collection has been already spawned before spawning it, and if it's not spawned yet, check if the schematic blocks (if any) contain a block that contains the current computed block.
If it contains that, it'll skip the block, and it'll check for other childrens.