### PR TITLE
Fix Teleport Player Rotation & Ragdoll Spawner

### DIFF
--- a/MapEditorReborn/API/Features/Objects/RagdollSpawnPointObject.cs
+++ b/MapEditorReborn/API/Features/Objects/RagdollSpawnPointObject.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using PlayerStatsSystem;
+
 namespace MapEditorReborn.API.Features.Objects
 {
     using System.Collections.Generic;
@@ -46,7 +48,7 @@ namespace MapEditorReborn.API.Features.Objects
         /// <inheritdoc cref="MapEditorObject.UpdateObject()"/>
         public override void UpdateObject()
         {
-            OnDestroy();
+            //OnDestroy();
 
             if (Random.Range(0, 101) > Base.SpawnChance)
                 return;
@@ -56,20 +58,23 @@ namespace MapEditorReborn.API.Features.Objects
                 Base.Name = ragdollNames[Random.Range(0, ragdollNames.Count)];
             }
 
-            /*
-            RagdollInfo ragdollInfo;
+
+            RagdollData ragdollInfo;
 
             if (byte.TryParse(Base.DeathReason, out byte deathReasonId) && deathReasonId <= 22)
-                ragdollInfo = new RagdollInfo(Server.Host.ReferenceHub, new UniversalDamageHandler(-1f, DeathTranslations.TranslationsById[deathReasonId]), Base.RoleType, transform.position, transform.rotation, Base.Name, double.MaxValue);
+                ragdollInfo = new RagdollData(Server.Host.ReferenceHub, new UniversalDamageHandler(-1f, DeathTranslations.TranslationsById[deathReasonId]), Base.RoleType, transform.position, transform.rotation, Base.Name, double.MaxValue);
             else
-                ragdollInfo = new RagdollInfo(Server.Host.ReferenceHub, new CustomReasonDamageHandler(Base.DeathReason), Base.RoleType, transform.position, transform.rotation, Base.Name, double.MaxValue);
-            */
+                ragdollInfo = new RagdollData(Server.Host.ReferenceHub, new CustomReasonDamageHandler(Base.DeathReason), Base.RoleType, transform.position, transform.rotation, Base.Name, double.MaxValue);
+            
 
-            // AttachedRagdoll = new Ragdoll(ragdollInfo, true);
+            AttachedRagdoll = Ragdoll.Create(ragdollInfo);
         }
 
         private void OnDestroy()
         {
+            if(AttachedRagdoll == null)
+                return;
+
             AttachedRagdoll.Destroy();
             AttachedRagdoll = null;
         }

--- a/MapEditorReborn/API/Features/Objects/TeleportObject.cs
+++ b/MapEditorReborn/API/Features/Objects/TeleportObject.cs
@@ -5,6 +5,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using PlayerRoles.FirstPersonControl;
+
 namespace MapEditorReborn.API.Features.Objects
 {
     using System;
@@ -178,8 +180,17 @@ namespace MapEditorReborn.API.Features.Objects
                 return;
 
             TeleportObject target = TargetFromId[choosenTeleporter];
+
+
+            Log.Debug($"Defined Rotation ({(target.Base.PlayerRotationX.HasValue ? target.Base.PlayerRotationX.Value.ToString() : "Not Defined")}, {(target.Base.PlayerRotationY.HasValue ? target.Base.PlayerRotationY.Value.ToString() : "Not Defined")})");
+            Vector2 PlayerRotation = new Vector2()
+            {
+                x = target.Base.PlayerRotationX ?? player.Rotation.x,
+                y = target.Base.PlayerRotationY ?? player.Rotation.y
+
+            };
             // new(target.Base.PlayerRotationX, target.Base.PlayerRotationY)
-            TeleportingEventArgs ev = new(this, target, player, gameObject, target.Position, null, Base.TeleportSoundId);
+            TeleportingEventArgs ev = new(this, target, player, gameObject, target.Position, PlayerRotation, Base.TeleportSoundId);
             Events.Handlers.Teleport.OnTeleporting(ev);
 
             if (!ev.IsAllowed)
@@ -202,17 +213,9 @@ namespace MapEditorReborn.API.Features.Objects
 
             player.Position = destination;
 
-            Vector2 syncRotation = player.Rotation;
-            // syncRotation.x = playerRotation.x ?? syncRotation.x;
-            // syncRotation.y = playerRotation.y ?? syncRotation.y;
+            player.Rotation = PlayerRotation;
+            Log.Debug($"Final Player Rotation ({PlayerRotation.x}, {PlayerRotation.y})");
 
-            /*
-            if (playerRotation.x.HasValue || playerRotation.y.HasValue)
-            {
-                player.ReferenceHub.playerMovementSync.NetworkRotationSync = syncRotation;
-                player.ReferenceHub.playerMovementSync.ForceRotation(playerRotation);
-            }
-            */
 
             if (teleportSoundId != -1)
             {

--- a/MapEditorReborn/Events/EventArgs/TeleportingEventArgs.cs
+++ b/MapEditorReborn/Events/EventArgs/TeleportingEventArgs.cs
@@ -21,14 +21,14 @@ namespace MapEditorReborn.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="TeleportingEventArgs"/> class.
         /// </summary>
-        public TeleportingEventArgs(TeleportObject entranceTeleport, TeleportObject exitTeleport, Player player, GameObject gameObject, Vector3 destination, object playerRotation, int teleportSoundId)
+        public TeleportingEventArgs(TeleportObject entranceTeleport, TeleportObject exitTeleport, Player player, GameObject gameObject, Vector3 destination, Vector2 playerRotation, int teleportSoundId)
         {
             EntranceTeleport = entranceTeleport;
             ExitTeleport = exitTeleport;
             Player = player;
             GameObject = gameObject;
             Destination = destination;
-            // PlayerRotation = playerRotation;
+            PlayerRotation = playerRotation;
             TeleportSoundId = teleportSoundId;
         }
 
@@ -60,7 +60,7 @@ namespace MapEditorReborn.Events.EventArgs
         /// <summary>
         /// Gets or sets the forced rotation of the player after teleport.
         /// </summary>
-        // public PlayerMovementSync.PlayerRotation PlayerRotation { get; set; }
+        public Vector2 PlayerRotation { get; set; }
 
         /// <summary>
         /// Gets or sets the teleport sound id played after teleport.


### PR DESCRIPTION
### Fixed Teleport Player Rotation:
 - Changed Character Class Manager . Rotation -> Exiled...Player.Rotation()
  
### Updated Teleporting Event Args Rotation:
  - Rotation is now a Vector2
  
### Fix Ragdoll Spawner:
  - Change some syntax and casts.
    
  tested locally, build passed and seems to work ingame