### PR TITLE
feat: auto-merge mode for LoadMapOnEvent

### DIFF
--- a/MapEditorReborn/API/Enums/LoadMapOnEventMode.cs
+++ b/MapEditorReborn/API/Enums/LoadMapOnEventMode.cs
@@ -1,0 +1,15 @@
+﻿namespace MapEditorReborn.API.Enums
+{
+    public enum LoadMapOnEventMode
+    {
+        /// <summary>
+        /// Picks a random map from the available maps.
+        /// </summary>
+        Random,
+
+        /// <summary>
+        /// Merges multiple maps into one and loads all of them.
+        /// </summary>
+        Merge
+    }
+}

--- a/MapEditorReborn/API/Features/MapUtils.cs
+++ b/MapEditorReborn/API/Features/MapUtils.cs
@@ -450,6 +450,35 @@ namespace MapEditorReborn.API.Features
             return data;
         }
 
+        /// <summary>
+        /// Merges two or more <see cref="MapSchematic"/>s into one.
+        /// </summary>
+        /// <param name="name">The name of the merged map schematic.</param>
+        /// <param name="maps">The list of <see cref="MapSchematic"/>s to merge.</param>
+        /// <returns>A new <see cref="MapSchematic"/> object that contains all of the elements from the input maps.</returns>
+        public static MapSchematic MergeMaps(string name, List<MapSchematic> maps)
+        {
+            MapSchematic outputMap = new (name);
+
+            foreach (MapSchematic map in maps)
+            {
+                outputMap.Doors.AddRange(map.Doors);
+                outputMap.WorkStations.AddRange(map.WorkStations);
+                outputMap.ItemSpawnPoints.AddRange(map.ItemSpawnPoints);
+                outputMap.PlayerSpawnPoints.AddRange(map.PlayerSpawnPoints);
+                outputMap.RagdollSpawnPoints.AddRange(map.RagdollSpawnPoints);
+                outputMap.ShootingTargets.AddRange(map.ShootingTargets);
+                outputMap.Primitives.AddRange(map.Primitives);
+                outputMap.LightSources.AddRange(map.LightSources);
+                outputMap.RoomLights.AddRange(map.RoomLights);
+                outputMap.Teleports.AddRange(map.Teleports);
+                outputMap.Lockers.AddRange(map.Lockers);
+                outputMap.Schematics.AddRange(map.Schematics);
+            }
+
+            return outputMap;
+        }
+
         internal static bool TryGetRandomMap(List<string> mapNames, out MapSchematic mapSchematic)
         {
             mapSchematic = null;

--- a/MapEditorReborn/Commands/UtilityCommands/Merge.cs
+++ b/MapEditorReborn/Commands/UtilityCommands/Merge.cs
@@ -1,10 +1,13 @@
-﻿namespace MapEditorReborn.Commands.UtilityCommands
+﻿
+namespace MapEditorReborn.Commands.UtilityCommands
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using API.Features;
     using API.Features.Serializable;
     using CommandSystem;
+    using Exiled.API.Features.Pools;
     using Exiled.Loader;
     using Exiled.Permissions.Extensions;
 
@@ -39,7 +42,7 @@
                 return false;
             }
 
-            MapSchematic outputMap = new(arguments.At(0));
+            List<MapSchematic> maps = ListPool<MapSchematic>.Pool.Get();
 
             for (int i = 1; i < arguments.Count; i++)
             {
@@ -51,19 +54,12 @@
                     return false;
                 }
 
-                outputMap.Doors.AddRange(map.Doors);
-                outputMap.WorkStations.AddRange(map.WorkStations);
-                outputMap.ItemSpawnPoints.AddRange(map.ItemSpawnPoints);
-                outputMap.PlayerSpawnPoints.AddRange(map.PlayerSpawnPoints);
-                outputMap.RagdollSpawnPoints.AddRange(map.RagdollSpawnPoints);
-                outputMap.ShootingTargets.AddRange(map.ShootingTargets);
-                outputMap.Primitives.AddRange(map.Primitives);
-                outputMap.LightSources.AddRange(map.LightSources);
-                outputMap.RoomLights.AddRange(map.RoomLights);
-                outputMap.Teleports.AddRange(map.Teleports);
-                outputMap.Lockers.AddRange(map.Lockers);
-                outputMap.Schematics.AddRange(map.Schematics);
+                maps.Add(map);
             }
+
+            var outputMap = MapUtils.MergeMaps(arguments.At(0), maps);
+
+            ListPool<MapSchematic>.Pool.Return(maps);
 
             File.WriteAllText(Path.Combine(MapEditorReborn.MapsDir, $"{outputMap.Name}.yml"), Loader.Serializer.Serialize(outputMap));
 

--- a/MapEditorReborn/Configs/Config.cs
+++ b/MapEditorReborn/Configs/Config.cs
@@ -8,6 +8,7 @@
 namespace MapEditorReborn.Configs
 {
     using System.ComponentModel;
+    using API.Enums;
     using Exiled.API.Interfaces;
 
     /// <summary>
@@ -68,5 +69,11 @@ namespace MapEditorReborn.Configs
         /// </summary>
         [Description("Option to load maps, when the specific event is called. If there are multiple maps, the random one will be choosen.")]
         public LoadMapOnEvent LoadMapOnEvent { get; private set; } = new ();
+
+        /// <summary>
+        /// Gets the mode used for selecting maps when using LoadMapOnEvent.
+        /// </summary>
+        [Description("The mode used for selecting maps when using the LoadMapOnEvent. Setting this to Random will pick a random map from the available maps. Setting this to Merge will automatically merge multiple maps into one and load all of them.")]
+        public LoadMapOnEventMode LoadMapOnEventMode { get; private set; } = LoadMapOnEventMode.Random;
     }
 }


### PR DESCRIPTION
### Description:

This PR introduces a new feature that adds flexibility in how maps are selected in `LoadMapOnEvent`. The update includes two strategies for selecting maps:

— **Random** (the current and default strategy): This strategy randomly selects a map from the available maps each time the event is triggered.
— **Merge** (the new strategy): This strategy automatically merges (like `mp merge`) all the maps specified in `LoadMapOnEvent`s properties when loading the event, instead of selecting just one.

### Check-list:
- [x] Everything is tested and working.
- [x] No breaking changes in code or configs.