### PR TITLE
Log schematic name at initialization

### DIFF
--- a/MapEditorReborn/API/Features/Objects/SchematicObject.cs
+++ b/MapEditorReborn/API/Features/Objects/SchematicObject.cs
@@ -46,6 +46,8 @@ namespace MapEditorReborn.API.Features.Objects
         /// <returns>Instance of this component.</returns>
         public SchematicObject Init(SchematicSerializable schematicSerializable, SchematicObjectDataList data)
         {
+            Log.Info($"Initializing schematic \"{schematicSerializable.SchematicName}\"");
+
             Base = schematicSerializable;
             SchematicData = data;
             DirectoryPath = data.Path;


### PR DESCRIPTION
Sometimes it is difficult to understand in which scheme an error occurred in creating teleporters / other objects. Therefore, it is good practice to log the name of the schema when it is initialized.