### PR TITLE
Fix NullReferenceException OnShootingDoor

### DIFF
--- a/MapEditorReborn/Events/Handlers/Internal/EventHandler.cs
+++ b/MapEditorReborn/Events/Handlers/Internal/EventHandler.cs
@@ -107,8 +107,10 @@ namespace MapEditorReborn.Events.Handlers.Internal
         {
             Vector3 forward = ev.Player.CameraTransform.forward;
             Vector3 position = ev.Player.CameraTransform.position;
-            Firearm firearm = ((Exiled.API.Features.Items.Firearm)ev.Player.CurrentItem).Base;
-            float maxDistance = firearm.BaseStats.MaxDistance();
+            if (ev.Player.CurrentItem is not Exiled.API.Features.Items.Firearm firearm)
+                return;
+
+            float maxDistance = firearm.Base.BaseStats.MaxDistance();
             if (!Physics.Raycast(position, forward, out RaycastHit raycastHit, maxDistance, StandardHitregBase.HitregMask))
                 return;
 
@@ -119,7 +121,7 @@ namespace MapEditorReborn.Events.Handlers.Internal
             if (doorObject.Base.IgnoredDamageSources.HasFlagFast(DoorDamageType.Weapon) || doorObject._remainingHealth <= 0f)
                 return;
 
-            doorObject._remainingHealth -= firearm.BaseStats.DamageAtDistance(firearm, raycastHit.distance) * 0.1f;
+            doorObject._remainingHealth -= firearm.Base.BaseStats.DamageAtDistance(firearm.Base, raycastHit.distance) * 0.1f;
             if (doorObject._remainingHealth <= 0f)
                 doorObject.BreakDoor();
 


### PR DESCRIPTION
My server usually shows this error, somehow the current item is not a firearm or is null.

```
System.NullReferenceException: Object reference not set to an instance of an object
  at MapEditorReborn.Events.Handlers.Internal.EventHandler.OnShootingDoor (Exiled.Events.EventArgs.Player.ShootingEventArgs ev) [0x0002c] in <2b35f8aa60d14daca7b405bb35627038>:0 
  at Exiled.Events.Extensions.Event.InvokeSafely[T] (Exiled.Events.Events+CustomEventHandler`1[TInterface] ev, T arg) [0x00021] in <b251a71acfb44405a8ba24e126ef798e>:0 
``` 